### PR TITLE
update STM32CubeIDE to V1.9.0

### DIFF
--- a/com.st.STM32CubeIDE.metainfo.xml
+++ b/com.st.STM32CubeIDE.metainfo.xml
@@ -21,7 +21,7 @@
 	<url type="homepage">https://www.st.com/content/st_com/en/products/development-tools/software-development-tools/stm32-software-development-tools/stm32-ides/stm32cubeide.html</url>
 	<launchable type="desktop-id">com.st.STM32CubeIDE.desktop</launchable>
 	<releases>
-        <release version="1.9.0" date="2021-05-26"/>
+        	<release version="1.9.0" date="2022-05-26"/>
 		<release version="1.7.0" date="2021-07-19"/>
 		<release version="1.6.1" date="2021-03-31"/>
 		<release version="1.6.0" date="2021-02-18"/>

--- a/com.st.STM32CubeIDE.metainfo.xml
+++ b/com.st.STM32CubeIDE.metainfo.xml
@@ -21,6 +21,7 @@
 	<url type="homepage">https://www.st.com/content/st_com/en/products/development-tools/software-development-tools/stm32-software-development-tools/stm32-ides/stm32cubeide.html</url>
 	<launchable type="desktop-id">com.st.STM32CubeIDE.desktop</launchable>
 	<releases>
+        <release version="1.9.0" date="2021-05-26"/>
 		<release version="1.7.0" date="2021-07-19"/>
 		<release version="1.6.1" date="2021-03-31"/>
 		<release version="1.6.0" date="2021-02-18"/>

--- a/com.st.STM32CubeIDE.yaml
+++ b/com.st.STM32CubeIDE.yaml
@@ -50,23 +50,23 @@ modules:
     buildsystem: simple
     build-commands: 
       - mkdir ${FLATPAK_DEST}/stm32cubeide
-      - chmod +x st-stlink-server.2.0.2-3-linux-amd64.install.sh
-      - ./st-stlink-server.2.0.2-3-linux-amd64.install.sh --tar -xvf
+      - chmod +x st-stlink-server.2.1.0-1-linux-amd64.install.sh
+      - ./st-stlink-server.2.1.0-1-linux-amd64.install.sh --tar -xvf
       - mv stlink-server ${FLATPAK_DEST}/bin/stlink-server
-      - chmod +x st-stm32cubeide_1.7.0_10852_20210715_0634_amd64.sh
-      - ./st-stm32cubeide_1.7.0_10852_20210715_0634_amd64.sh --tar -xvf
-      - tar -xzvf st-stm32cubeide_1.7.0_10852_20210715_0634_amd64.tar.gz -C ${FLATPAK_DEST}/stm32cubeide/
+      - chmod +x st-stm32cubeide_1.9.0_12015_20220302_0855_amd64.sh
+      - ./st-stm32cubeide_1.9.0_12015_20220302_0855_amd64.sh --tar -xvf
+      - tar -xzvf st-stm32cubeide_1.9.0_12015_20220302_0855_amd64.tar.gz -C ${FLATPAK_DEST}/stm32cubeide/
       - install -D icon.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
       - install -t ${FLATPAK_DEST}/share/applications/ -Dm644 com.st.STM32CubeIDE.desktop
       - install -t ${FLATPAK_DEST}/share/appdata/ -Dm644 com.st.STM32CubeIDE.metainfo.xml
       - install -t ${FLATPAK_DEST}/bin -Dm755 stm32cubeide
     sources:
       - type: archive
-        url: https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/d5/f6/71/a8/3f/91/40/97/stm32cubeide_lnx/files/st-stm32cubeide_1.7.0_10852_20210715_0634_amd64.sh.zip/jcr:content/translations/en.st-stm32cubeide_1.7.0_10852_20210715_0634_amd64.sh.zip
-        sha256: bfe2fb78652cbea961c46da9a71640b3b00eaf8137d6f258622638d65fb85ae1
+        url: https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/6c/ed/b5/05/5d/2f/44/f3/stm32cubeide_lnx/files/st-stm32cubeide_1.9.0_12015_20220302_0855_amd64.sh.zip/jcr:content/translations/en.st-stm32cubeide_1.9.0_12015_20220302_0855_amd64.sh.zip
+        sha256: fbb1c8dae35fe1bceba167db90041eab2dbd309ecbe3b6d81f22f0520ebc7fb2
       - type: archive
-        url: https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/85/60/5e/a3/9e/77/43/c0/st-link-serveur/files/st-link-server.zip/jcr:content/translations/en.st-link-server.zip
-        sha256: 45a751051c64cff9fa9797462131a8e5cfee5fba7911c6e69fee5b03f2bd15e3
+        url: https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/09/9f/79/67/ed/f9/45/d0/st-link-server_v2-1-0/files/st-link-server_v2-1-0.zip/jcr:content/translations/en.st-link-server_v2-1-0.zip
+        sha256: 135d924b303b8838b45fe5078def02037502f93023520f6003690fb754a1e123
       - type: file
         path: com.st.STM32CubeIDE.metainfo.xml
       - type: file


### PR DESCRIPTION
Updated STM32CubeIDE from V1.7.0 to the current latest, V1.9.0
Update ST-link server to the latest v2.1.0-1