### PR TITLE
fix usb flashing and various updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.st.STM32CubeIDE.metainfo.xml
+++ b/com.st.STM32CubeIDE.metainfo.xml
@@ -17,10 +17,16 @@
 		<p>
 		STM32CubeIDE also includes standard and advanced debugging features including views of CPU core registers, memories, and peripheral registers, as well as live variable watch, Serial Wire Viewer interface, or fault analyzer.
 		</p>
+		<p>
+		Note: For flashing to work properly you will need to add udev rules according to your device. If your device has an id of 0483:374b (check lsusb), you will need to create a file in /etc/udev/rules.d/ with the contents:
+		SUBSYSTEMS=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="374b", GROUP="users", MODE="0666"
+		and either reboot or run: sudo udevadm control --reload
+		</p>
 	</description>
 	<url type="homepage">https://www.st.com/content/st_com/en/products/development-tools/software-development-tools/stm32-software-development-tools/stm32-ides/stm32cubeide.html</url>
 	<launchable type="desktop-id">com.st.STM32CubeIDE.desktop</launchable>
 	<releases>
+		<release version="1.10.1" date="2022-07-07"/>
         	<release version="1.9.0" date="2022-05-26"/>
 		<release version="1.7.0" date="2021-07-19"/>
 		<release version="1.6.1" date="2021-03-31"/>

--- a/com.st.STM32CubeIDE.yaml
+++ b/com.st.STM32CubeIDE.yaml
@@ -1,25 +1,27 @@
 app-id: com.st.STM32CubeIDE
 runtime: org.gnome.Platform
-runtime-version: '41'
+runtime-version: '42'
 sdk: org.gnome.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk11
+  - org.freedesktop.Sdk.Extension.openjdk17
 command: stm32cubeide
 finish-args:
   - --socket=x11
-  - --share=ipc
   - --socket=pulseaudio
   - --share=network
-  - --allow=devel
-  - --filesystem=host
+  - --filesystem=home
   - --device=all
-  - --socket=session-bus
   - --env=PATH=/app/bin:/app/jdk/bin:/usr/bin
+  - --persist=.eclipse
+  - --persist=.java
+  - --persist=.stmcube
+  - --persist=STM32Cube
+  - --persist=.saros
 modules:
   - name: openjdk
     buildsystem: simple
     build-commands:
-      - /usr/lib/sdk/openjdk11/installjdk.sh
+      - /usr/lib/sdk/openjdk17/installjdk.sh
 
   - name: ncurses
     no-autogen: true
@@ -46,6 +48,8 @@ modules:
           stable-only: true
           url-template: https://ftp.gnu.org/gnu/ncurses/ncurses-$version.tar.gz
 
+  - shared-modules/libusb/libusb.json   
+
   - name: stm32cubeide
     buildsystem: simple
     build-commands:
@@ -53,17 +57,17 @@ modules:
       - chmod +x st-stlink-server.2.1.0-1-linux-amd64.install.sh
       - ./st-stlink-server.2.1.0-1-linux-amd64.install.sh --tar -xvf
       - mv stlink-server ${FLATPAK_DEST}/bin/stlink-server
-      - chmod +x st-stm32cubeide_1.9.0_12015_20220302_0855_amd64.sh
-      - ./st-stm32cubeide_1.9.0_12015_20220302_0855_amd64.sh --tar -xvf
-      - tar -xzvf st-stm32cubeide_1.9.0_12015_20220302_0855_amd64.tar.gz -C ${FLATPAK_DEST}/stm32cubeide/
+      - chmod +x st-stm32cubeide_1.10.1_12716_20220707_0928_amd64.sh
+      - ./st-stm32cubeide_1.10.1_12716_20220707_0928_amd64.sh --tar -xvf
+      - tar -xzvf st-stm32cubeide_1.10.1_12716_20220707_0928_amd64.tar.gz -C ${FLATPAK_DEST}/stm32cubeide/
       - install -D icon.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
       - install -t ${FLATPAK_DEST}/share/applications/ -Dm644 com.st.STM32CubeIDE.desktop
       - install -t ${FLATPAK_DEST}/share/appdata/ -Dm644 com.st.STM32CubeIDE.metainfo.xml
       - install -t ${FLATPAK_DEST}/bin -Dm755 stm32cubeide
     sources:
       - type: archive
-        url: https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/6c/ed/b5/05/5d/2f/44/f3/stm32cubeide_lnx/files/st-stm32cubeide_1.9.0_12015_20220302_0855_amd64.sh.zip/jcr:content/translations/en.st-stm32cubeide_1.9.0_12015_20220302_0855_amd64.sh.zip
-        sha256: fbb1c8dae35fe1bceba167db90041eab2dbd309ecbe3b6d81f22f0520ebc7fb2
+        url: https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/e7/6e/03/0a/97/9f/49/2d/stm32cubeide_lnx/files/st-stm32cubeide_1.10.1_12716_20220707_0928_amd64.sh.zip/jcr:content/translations/en.st-stm32cubeide_1.10.1_12716_20220707_0928_amd64.sh.zip
+        sha256: d657b57a837ca523ac43f03e65ce9cceff2a7f914e49a33a75ce4471f600e93b
       - type: archive
         url: https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/09/9f/79/67/ed/f9/45/d0/st-link-server_v2-1-0/files/st-link-server_v2-1-0.zip/jcr:content/translations/en.st-link-server_v2-1-0.zip
         sha256: 135d924b303b8838b45fe5078def02037502f93023520f6003690fb754a1e123
@@ -76,4 +80,5 @@ modules:
       - type: script
         dest-filename: stm32cubeide
         commands:
+          - unset FLATPAK_SANDBOX_DIR
           - exec /app/stm32cubeide/stm32cubeide "$@"


### PR DESCRIPTION
This should fix #2 #15 and #16 
In order for usb flashing to work, the user needs to manually add a udev rule specific to the used device, for which I added a brief explanation to the application description.
Things that were changed:

- add 'libusb', which seems to be required by st-link (st-link server won't start without it)
- update org.gnome.Platform runtime to version 42
- update STM32CubeIDE to 1.10.1
- update java to version 17
- add `unset FLATPAK_SANDBOX_DIR` to the launch script. This works around "flatpak detection" added to eclipse [here](https://bugs.eclipse.org/bugs/show_bug.cgi?id=565142), which would try to run commands outside of the sandbox otherwise. That would be an issue, because our toolchain lives inside the sandbox.

I have been using this version for the past semester with a STM32 Nucleo-L476RG, and flashing and debugging seems to work fine :)