### PR TITLE
Update versions (not working)

### DIFF
--- a/com.st.STM32CubeIDE.metainfo.xml
+++ b/com.st.STM32CubeIDE.metainfo.xml
@@ -26,6 +26,7 @@
 	<url type="homepage">https://www.st.com/content/st_com/en/products/development-tools/software-development-tools/stm32-software-development-tools/stm32-ides/stm32cubeide.html</url>
 	<launchable type="desktop-id">com.st.STM32CubeIDE.desktop</launchable>
 	<releases>
+		<release version="1.16.0" date="2024-08-27"/>
 		<release version="1.12.0" date="2023-03-19"/>
 		<release version="1.10.1" date="2022-07-07"/>
 		<release version="1.9.0" date="2022-05-26"/>

--- a/com.st.STM32CubeIDE.yaml
+++ b/com.st.STM32CubeIDE.yaml
@@ -1,6 +1,6 @@
 app-id: com.st.STM32CubeIDE
 runtime: org.gnome.Platform
-runtime-version: '44'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
@@ -52,25 +52,28 @@ modules:
 
   - name: stm32cubeide
     buildsystem: simple
+    build-options:
+      no-debuginfo: true
+      no-debuginfo-compression: true
     build-commands:
       - mkdir ${FLATPAK_DEST}/stm32cubeide
-      - chmod +x st-stlink-server.2.1.0-1-linux-amd64.install.sh
-      - ./st-stlink-server.2.1.0-1-linux-amd64.install.sh --tar -xvf
+      - chmod +x st-stlink-server.2.1.1-1-linux-amd64.install.sh
+      - ./st-stlink-server.2.1.1-1-linux-amd64.install.sh --tar -xvf
       - mv stlink-server ${FLATPAK_DEST}/bin/stlink-server
-      - chmod +x st-stm32cubeide_1.12.0_14980_20230301_1550_amd64.sh
-      - ./st-stm32cubeide_1.12.0_14980_20230301_1550_amd64.sh --tar -xvf
-      - tar -xzvf st-stm32cubeide_1.12.0_14980_20230301_1550_amd64.tar.gz -C ${FLATPAK_DEST}/stm32cubeide/
+      - chmod +x st-stm32cubeide_1.16.0_21983_20240628_1741_amd64.sh
+      - ./st-stm32cubeide_1.16.0_21983_20240628_1741_amd64.sh --tar -xvf
+      - tar -xzvf st-stm32cubeide_1.16.0_21983_20240628_1741_amd64.tar.gz -C ${FLATPAK_DEST}/stm32cubeide/
       - install -D icon.png ${FLATPAK_DEST}/share/icons/hicolor/256x256/apps/${FLATPAK_ID}.png
       - install -t ${FLATPAK_DEST}/share/applications/ -Dm644 com.st.STM32CubeIDE.desktop
       - install -t ${FLATPAK_DEST}/share/appdata/ -Dm644 com.st.STM32CubeIDE.metainfo.xml
       - install -t ${FLATPAK_DEST}/bin -Dm755 stm32cubeide
     sources:
       - type: archive
-        url: https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/bc/99/f5/62/06/da/4d/eb/stm32cubeide_lnx/files/st-stm32cubeide_1.12.0_14980_20230301_1550_amd64.sh.zip/jcr:content/translations/en.st-stm32cubeide_1.12.0_14980_20230301_1550_amd64.sh.zip
-        sha256: 287129ea5d1fc283ae34404ccb15891f8e767587d43f9c43504ee9cdb73d55f7
+        url: https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group1/d3/77/3e/45/79/2b/47/46/stm32cubeide-lnx/files/st-stm32cubeide_1.16.0_21983_20240628_1741_amd64.sh.zip/jcr:content/translations/en.st-stm32cubeide_1.16.0_21983_20240628_1741_amd64.sh.zip
+        sha256: 831522a542c162295336ea2ca93fc5793c2888e3a4f385b327b9dd88bc1bdd0f
       - type: archive
-        url: https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/09/9f/79/67/ed/f9/45/d0/st-link-server_v2-1-0/files/st-link-server_v2-1-0.zip/jcr:content/translations/en.st-link-server_v2-1-0.zip
-        sha256: 135d924b303b8838b45fe5078def02037502f93023520f6003690fb754a1e123
+        url: https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/98/41/e8/53/44/80/41/92/st-link-server-v2-1-1/files/st-link-server-v2-1-1.zip/jcr:content/translations/en.st-link-server-v2-1-1.zip
+        sha256: a84a0ada7c9b6343e559dacd37e42a815c500d0f4a517db3d1e511d056903bf6
       - type: file
         path: com.st.STM32CubeIDE.metainfo.xml
       - type: file

--- a/com.st.STM32CubeIDE.yaml
+++ b/com.st.STM32CubeIDE.yaml
@@ -9,6 +9,7 @@ finish-args:
   - --socket=x11
   - --socket=pulseaudio
   - --share=network
+  - --share=ipc
   - --filesystem=home
   - --device=all
   - --env=PATH=/app/bin:/app/jdk/bin:/usr/bin

--- a/com.st.STM32CubeIDE.yaml
+++ b/com.st.STM32CubeIDE.yaml
@@ -56,7 +56,14 @@ modules:
     build-options:
       no-debuginfo: true
       no-debuginfo-compression: true
+      build-args:
+        - --share=network
     build-commands:
+      - "curl 'https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group1/d3/77/3e/45/79/2b/47/46/stm32cubeide-lnx/files/st-stm32cubeide_1.16.0_21983_20240628_1741_amd64.sh.zip/jcr:content/translations/en.st-stm32cubeide_1.16.0_21983_20240628_1741_amd64.sh.zip' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0' -H 'Accept-Encoding: identity' -O"
+      - unzip en.st-stm32cubeide_1.16.0_21983_20240628_1741_amd64.sh.zip -d .
+      - "curl 'https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/98/41/e8/53/44/80/41/92/st-link-server-v2-1-1/files/st-link-server-v2-1-1.zip/jcr:content/translations/en.st-link-server-v2-1-1.zip' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0' -H 'Accept-Encoding: identity' -O"
+      - unzip en.st-link-server-v2-1-1.zip -d .
+      - mv ./en.st-link-server_v2.1.1-2/st-stlink-server.2.1.1-1-linux-amd64.install.sh .
       - mkdir ${FLATPAK_DEST}/stm32cubeide
       - chmod +x st-stlink-server.2.1.1-1-linux-amd64.install.sh
       - ./st-stlink-server.2.1.1-1-linux-amd64.install.sh --tar -xvf
@@ -69,12 +76,6 @@ modules:
       - install -t ${FLATPAK_DEST}/share/appdata/ -Dm644 com.st.STM32CubeIDE.metainfo.xml
       - install -t ${FLATPAK_DEST}/bin -Dm755 stm32cubeide
     sources:
-      - type: archive
-        url: https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group1/d3/77/3e/45/79/2b/47/46/stm32cubeide-lnx/files/st-stm32cubeide_1.16.0_21983_20240628_1741_amd64.sh.zip/jcr:content/translations/en.st-stm32cubeide_1.16.0_21983_20240628_1741_amd64.sh.zip
-        sha256: 831522a542c162295336ea2ca93fc5793c2888e3a4f385b327b9dd88bc1bdd0f
-      - type: archive
-        url: https://www.st.com/content/ccc/resource/technical/software/sw_development_suite/group0/98/41/e8/53/44/80/41/92/st-link-server-v2-1-1/files/st-link-server-v2-1-1.zip/jcr:content/translations/en.st-link-server-v2-1-1.zip
-        sha256: a84a0ada7c9b6343e559dacd37e42a815c500d0f4a517db3d1e511d056903bf6
       - type: file
         path: com.st.STM32CubeIDE.metainfo.xml
       - type: file


### PR DESCRIPTION
**Updated:**
- Gnome runtime to 46
- CubeIDE to 1.16.0
- ST-Link server to 2.1.1

---
This is my first pull request
And this is my first time working with flatpak
Please check it out

---
Fixes #27 #28 