### PR TITLE
EOL

### DIFF
--- a/com.st.STM32CubeIDE.yaml
+++ b/com.st.STM32CubeIDE.yaml
@@ -9,6 +9,7 @@ finish-args:
   - --socket=x11
   - --socket=pulseaudio
   - --share=network
+  - --share=ipc
   - --filesystem=home
   - --device=all
   - --env=PATH=/app/bin:/app/jdk/bin:/usr/bin

--- a/com.st.STM32CubeIDE.yaml
+++ b/com.st.STM32CubeIDE.yaml
@@ -41,13 +41,13 @@ modules:
       - /lib/*.la
     sources:
       - type: archive
-        url: https://ftp.gnu.org/gnu/ncurses/ncurses-6.4.tar.gz
+        url: https://invisible-island.net/archives/ncurses/ncurses-6.4.tar.gz
         sha256: 6931283d9ac87c5073f30b6290c4c75f21632bb4fc3603ac8100812bed248159
         x-checker-data:
           type: anitya
           project-id: 234776
           stable-only: true
-          url-template: https://ftp.gnu.org/gnu/ncurses/ncurses-$version.tar.gz
+          url-template: https://invisible-island.net/archives/ncurses/ncurses-$version.tar.gz
 
   - shared-modules/libusb/libusb.json
 

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64"],
+  "end-of-life": "This application is no longer maintained."
 }


### PR DESCRIPTION
For some reason, downloading the files no longer works when doing it from flathub CI. Building locally with flatpak-builder works. No one seem to have been able to figure out how to solve it for years, so I think it's time to EOL it.